### PR TITLE
Add range slider to the programming timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Install the dependencies and run locally...
 
 - `npm install`
 
-- `npm run dev`
+- `npm run dev` - for local developement
+
+- `npm start` - for production
 
 > **NOTE** - By default, the server will only respond to requests from localhost. To allow connections from other computers, edit the `sirv` commands in package.json to include the option `--host 0.0.0.0`.
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "rollup -c -w",
     "start": "sirv public --single",
     "lint": "eslint src/**/**/*.svelte tests/**/**/*.js",
+    "lint:fix": "eslint --fix src/**/**/*.svelte tests/**/**/*.js",
     "test": "jest",
     "test:watch": "jest --watch"
   },

--- a/src/timer/SetupTimer.svelte
+++ b/src/timer/SetupTimer.svelte
@@ -20,7 +20,7 @@
   let hideInput = false;
   const sessionData = {};
 
-  const INITIAL_VALUE_MIN = 15;
+  const INITIAL_VALUE = 15;
   const MAX_VALUE_MIN = 120;
   const MIN_VALUE_MIN = 1;
 
@@ -68,10 +68,6 @@
       console.error(err);
     }
   }
-
-  const updateInput = (value, target) => {
-    document.getElementById(target).value = value;
-  };
 </script>
 
 <style>
@@ -171,18 +167,16 @@
         min={MIN_VALUE_MIN}
         data-testid="setup-timer-new-timer-input"
         on:keydown={initNewSession}
-        on:input={(event) => updateInput(event.target.value, 'range-slider')}
         placeholder="enter duration (mins)"
-        value={15}
+        value={INITIAL_VALUE}
         required />
       <input
         id="range-slider"
         data-testid="range-slider"
-        on:input={(event) => updateInput(event.target.value, 'setup-timer-new-timer-input')}
         type="range"
         min={MIN_VALUE_MIN}
         max={MAX_VALUE_MIN}
-        value={INITIAL_VALUE_MIN} />
+        value={INITIAL_VALUE} />
     </div>
 {/if}
 

--- a/src/timer/SetupTimer.svelte
+++ b/src/timer/SetupTimer.svelte
@@ -20,6 +20,10 @@
   let hideInput = false;
   const sessionData = {};
 
+  const INITIAL_VALUE_MIN = 15;
+  const MAX_VALUE_MIN = 120;
+  const MIN_VALUE_MIN = 1;
+
   onMount(async () => {
     sessionStorage.clear();
     const existingSessionPath = initRouter();
@@ -99,7 +103,7 @@
     border-radius: 50%;
   }
 
-  input {
+  input[type="number"] {
     position: absolute;
     top: 65%;
     left: 50%;
@@ -160,24 +164,26 @@
       class="input-svg"
       src="/new-timer-input.svg"
       alt="input timer duration minutes" />
-    <div></div>
-    <input
-      id="setup-input"
-      type="number"
-      data-testid="setup-timer-new-timer-input"
-      on:keydown={initNewSession}
-      on:input={(event) => updateInput(event.target.value, 'range-slider')}
-      placeholder="enter duration (mins)"
-      value={15}
-      required />
-    <input
-      id="range-slider"
-      on:input={(event) => updateInput(event.target.value, 'setup-input')}
-      type="range"
-      min="1"
-      max="120"
-      value="10" />
-  </div>
+      <input
+        id="setup-timer-new-timer-input"
+        type="number"
+        max={MAX_VALUE_MIN}
+        min={MIN_VALUE_MIN}
+        data-testid="setup-timer-new-timer-input"
+        on:keydown={initNewSession}
+        on:input={(event) => updateInput(event.target.value, 'range-slider')}
+        placeholder="enter duration (mins)"
+        value={15}
+        required />
+      <input
+        id="range-slider"
+        data-testid="range-slider"
+        on:input={(event) => updateInput(event.target.value, 'setup-timer-new-timer-input')}
+        type="range"
+        min={MIN_VALUE_MIN}
+        max={MAX_VALUE_MIN}
+        value={INITIAL_VALUE_MIN} />
+    </div>
 {/if}
 
 {#if message || invalidInput}

--- a/src/timer/SetupTimer.svelte
+++ b/src/timer/SetupTimer.svelte
@@ -147,17 +147,78 @@ import {
     border-bottom: solid #993299;
   }
 
-  .input-svg, .new-timer-svg {
+  #range-slider {
+    position: absolute;
+    top: 70%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 25%;
+  }
+
+  .input-svg,
+  .new-timer-svg {
     fill: none;
     width: 68vh;
   }
 
   .timer-container {
     position: absolute;
-    height:75%;
+    height: 75%;
     width: 100%;
     top: 70%;
     left: 50%;
     transform: translate(-50%, -50%);
   }
 </style>
+
+{#if !newTimer && !existingSession}
+  <h3>Allow notifications so we can alert you when time's up</h3>
+  <button
+    data-testid="setup-timer-new-timer-button"
+    on:click={() => (newTimer = true)}>
+    <img
+      class="new-timer-svg"
+      src="/new-timer-button.svg"
+      alt="start new timer" />
+  </button>
+{/if}
+
+{#if newTimer && !hideInput}
+  <div class="input-container">
+    <h2>enter duration (mins)</h2>
+    <img
+      class="input-svg"
+      src="/new-timer-input.svg"
+      alt="input timer duration minutes" />
+    <div></div>
+    <input
+      id="setup-input"
+      type="number"
+      data-testid="setup-timer-new-timer-input"
+      on:keydown={initNewSession}
+      on:input={(event) => updateInput(event.target.value, 'range-slider')}
+      placeholder="enter duration (mins)"
+      value={15}
+      required />
+    <input
+      id="range-slider"
+      on:input={(event) => updateInput(event.target.value, 'setup-input')}
+      type="range"
+      min="1"
+      max="120"
+      value="10" />
+  </div>
+{/if}
+
+{#if message || invalidInput}
+  <h2 class="message">{message}</h2>
+{/if}
+{#if typeof input === 'string'}
+  <h3>{input}</h3>
+{/if}
+
+{#if (newTimer && hideInput) || (sessionData && existingSession && hideInput)}
+  <div class="timer-container">
+    <Timer {sessionData} bind:message bind:invalidInput />
+  </div>
+{/if}

--- a/src/timer/SetupTimer.svelte
+++ b/src/timer/SetupTimer.svelte
@@ -5,11 +5,11 @@
   import Timer from './Timer.svelte';
   import {
     newSession, joinSession,
-  } from '../utils/handleSession.js';
+} from '../utils/handleSession.js';
   import {
     initRouter, redirect,
 } from '../router/router.js';
-import {
+  import {
     validateInput, minsToMillis,
 } from '../utils/utils.js';
   let input;
@@ -36,7 +36,7 @@ import {
   async function initNewSession(e) {
     if (e.keyCode === 13) {
       input = validateInput(minsToMillis(e.target.value), minsToMillis(120));
-      if (typeof  input === 'number') {
+      if (typeof input === 'number') {
         try {
           const response = await newSession(e.target.value);
           Object.assign(sessionData, response.Session);
@@ -64,48 +64,18 @@ import {
       console.error(err);
     }
   }
+
+  const updateInput = (value, target) => {
+    document.getElementById(target).value = value;
+  };
 </script>
 
-  {#if !newTimer && !existingSession}
-  <h3>Allow notifications so we can alert you when time's up</h3>
-    <button
-      data-testid="setup-timer-new-timer-button"
-      on:click={() => (newTimer = true)}>
-      <img class="new-timer-svg" src="/new-timer-button.svg" alt="start new timer"/>
-    </button>
-  {/if}
-
-  {#if newTimer && !hideInput}
-  <div class="input-container">
-    <img class="input-svg" src="/new-timer-input.svg" alt="input timer duration minutes"/>
-    <input
-    autofocus
-    data-testid="setup-timer-new-timer-input"
-    on:keydown={initNewSession}
-    placeholder="enter duration (mins)"
-    required
-    />
-  </div>
-  {/if}
-
-  {#if message || invalidInput}
-    <h2 class="message">{message}</h2>
-  {/if}
-  {#if typeof input === 'string'}
-    <h3>{input}</h3>
-  {/if}
-
-  {#if (newTimer && hideInput) || (sessionData && existingSession && hideInput)}
-    <div class="timer-container">
-      <Timer {sessionData} bind:message bind:invalidInput />
-    </div>
-  {/if}
 <style>
-
-  h3, h2 {
+  h3,
+  h2 {
     position: absolute;
     font-family: Kalam-Regular;
-    color:  #eeaaffff;
+    color: #eeaaffff;
     font-size: 1.8em;
     font-weight: 100;
     left: 50%;
@@ -121,11 +91,11 @@ import {
 
   button {
     background-color: Transparent;
-    background-repeat:no-repeat;
+    background-repeat: no-repeat;
     border: none;
-    cursor:pointer;
+    cursor: pointer;
     overflow: hidden;
-    outline:none;
+    outline: none;
     border-radius: 50%;
   }
 

--- a/src/timer/SetupTimer.svelte
+++ b/src/timer/SetupTimer.svelte
@@ -12,6 +12,7 @@
   import {
     validateInput, minsToMillis,
 } from '../utils/utils.js';
+
   let input;
   export let newTimer = false;
   export let existingSession = false;
@@ -20,9 +21,9 @@
   let hideInput = false;
   const sessionData = {};
 
-  const INITIAL_VALUE = 15;
-  const MAX_VALUE_MIN = 120;
-  const MIN_VALUE_MIN = 1;
+  const INITIAL_VALUE_MINS = 15;
+  const MAX_VALUE_MINS = 120;
+  const MIN_VALUE_MINS = 1;
 
   onMount(async () => {
     sessionStorage.clear();
@@ -39,7 +40,7 @@
 
   async function initNewSession(e) {
     if (e.keyCode === 13) {
-      input = validateInput(minsToMillis(e.target.value), minsToMillis(120));
+      input = validateInput(minsToMillis(e.target.value), minsToMillis(MAX_VALUE_MINS));
       if (typeof input === 'number') {
         try {
           const response = await newSession(e.target.value);
@@ -163,20 +164,20 @@
       <input
         id="setup-timer-new-timer-input"
         type="number"
-        max={MAX_VALUE_MIN}
-        min={MIN_VALUE_MIN}
+        max={MAX_VALUE_MINS}
+        min={MIN_VALUE_MINS}
         data-testid="setup-timer-new-timer-input"
         on:keydown={initNewSession}
         placeholder="enter duration (mins)"
-        value={INITIAL_VALUE}
+        value={INITIAL_VALUE_MINS}
         required />
       <input
         id="range-slider"
         data-testid="range-slider"
         type="range"
-        min={MIN_VALUE_MIN}
-        max={MAX_VALUE_MIN}
-        value={INITIAL_VALUE} />
+        min={MIN_VALUE_MINS}
+        max={MAX_VALUE_MINS}
+        value={INITIAL_VALUE_MINS} />
     </div>
 {/if}
 

--- a/tests/timer/SetupTimer.test.js
+++ b/tests/timer/SetupTimer.test.js
@@ -49,13 +49,13 @@ describe('Conditional rendering of the Timer Component', () => {
   });
 
   it('if duration isNaN(), then don\'t begin timer and reprompt', async () => {
-    const { getByText, getByTestId } = render(SetupTimer);
+    const { getByTestId } = render(SetupTimer);
     const newTimerButton = getByTestId('setup-timer-new-timer-button');
     await fireEvent.click(newTimerButton);
     const input = getByTestId('setup-timer-new-timer-input');
     await fireEvent.input(input, { target: { value: 'NOT A NUMBER' } });
     await fireEvent.keyDown(input, { keyCode: '13' });
-    const timerText = getByText('Please enter a number (mins) between 0 and 120');
+    const timerText = getByTestId('setup-timer-new-timer-button');
     expect(timerText).toBeInTheDocument();
   });
 
@@ -94,8 +94,8 @@ describe('Conditional rendering of the Timer Component', () => {
     await fireEvent.click(newTimerButton);
     const input = getByTestId('setup-timer-new-timer-input');
     expect(input).toBeInTheDocument();
-    await fireEvent.input(input, { target: { value: '9' } });
-    expect(input).toHaveValue('9');
+    await fireEvent.input(input, { target: { value: 9 } });
+    expect(input).toHaveValue(9);
     await fireEvent.keyDown(input, { keyCode: '13' });
     expect(mockHandleSession.newSession).toBeCalled();
   });

--- a/tests/timer/SetupTimer.test.js
+++ b/tests/timer/SetupTimer.test.js
@@ -55,7 +55,7 @@ describe('Conditional rendering of the Timer Component', () => {
     const input = getByTestId('setup-timer-new-timer-input');
     await fireEvent.input(input, { target: { value: 'NOT A NUMBER' } });
     await fireEvent.keyDown(input, { keyCode: '13' });
-    const timerText = getByTestId('setup-timer-new-timer-button');
+    const timerText = getByTestId('setup-timer-new-timer-input');
     expect(timerText).toBeInTheDocument();
   });
 


### PR DESCRIPTION
This PR was raised to:

- Add the type number on the main input, which allows enforcement of the 1-120 range in the allowed values, denies non-numerical characters, adds nice keyboard shortcuts, allows for less testing (and maybe need for error messages) of the UI, and feel semantically cleaner
- Trade removing the auto-focus (an accessibility bugbear - see "Avoid using the autofocus attribute" in https://www.a11yproject.com/checklist/) for a pre-filled sane default of 15 minutes
- Add range slider for rapid value setting using a mouse
- Add a lint:fix value in script to get some rapid changes

Apologies for some of the values being out of place, it seems to come from my linter.
The commit format is also not the one you follow, that can be fixed on squashing the commits.